### PR TITLE
feat: 질문 리스트가 없을 때 보여질 UI 구현

### DIFF
--- a/src/assets/img/question-emptyBox.svg
+++ b/src/assets/img/question-emptyBox.svg
@@ -1,0 +1,7 @@
+<svg width="176" height="180" viewBox="0 0 176 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M150 99.4065H112.8L100.4 117.254H75.6L63.2 99.4065H26" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M47.39 58.4168L26 99.4066V135.102C26 138.257 27.3064 141.284 29.6319 143.515C31.9573 145.746 35.1113 147 38.4 147H137.6C140.889 147 144.043 145.746 146.368 143.515C148.694 141.284 150 138.257 150 135.102V99.4066L128.61 58.4168C127.583 56.4345 126.001 54.7662 124.04 53.5996C122.08 52.4331 119.819 51.8144 117.512 51.8132H58.488C56.1811 51.8144 53.9202 52.4331 51.9597 53.5996C49.9991 54.7662 48.4166 56.4345 47.39 58.4168V58.4168Z" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M88.001 25L88.001 35.0549" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round"/>
+<path d="M110.007 31.2854L102.597 38.3953" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round"/>
+<path d="M65.9946 31.2854L73.4043 38.3953" stroke="#E4D5C9" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/components/containers/Question/EmptyQuestion/EmptyQuestion.jsx
+++ b/src/components/containers/Question/EmptyQuestion/EmptyQuestion.jsx
@@ -1,0 +1,14 @@
+import * as S from "@/components/containers/Question/EmptyQuestion/EmptyQuestion.style";
+import EmptyBox from "@/assets/img/question-emptyBox.svg";
+
+export default function EmptyQuestion() {
+  return (
+    <S.Container>
+      <S.EmptyImg src={EmptyBox} alt="비어있는피드이미지" />
+      <S.Message>
+        {/* Todo: 프로필 이름 API 연동 후 수정 */}
+        <span>프로필이름</span>님에게 <br />첫 질문을 남겨보세요!
+      </S.Message>
+    </S.Container>
+  );
+}

--- a/src/components/containers/Question/EmptyQuestion/EmptyQuestion.style.js
+++ b/src/components/containers/Question/EmptyQuestion/EmptyQuestion.style.js
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+import { media } from "@/styles/media";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 120px 0;
+
+  ${media.tablet`
+    padding: 70px 0;
+ `};
+`;
+
+export const EmptyImg = styled.img`
+  width: 100%;
+  max-width: 120px;
+
+  ${media.tablet`
+    max-width: 150px;
+  `};
+`;
+
+export const Message = styled.p`
+  margin-top: -8px;
+
+  color: ${({ theme }) => theme.colors.brown20};
+  ${({ theme }) => theme.typography.body2};
+  font-weight: 500;
+  text-align: center;
+
+  & span {
+    color: ${({ theme }) => theme.colors.brown30};
+    font-weight: 700;
+  }
+
+  ${media.tablet`
+    ${({ theme }) => theme.typography.body1};
+    font-weight: 500;
+    line-height: 30px;
+  `};
+`;


### PR DESCRIPTION
## 💡 작업 내용

- 질문 데이터가 없을 경우 표시할 안내 문구 및 이미지 추가
- 화면만 제작하고 아직 질문 데이터가 없을 조건부 렌더링은 아직 안 한 상태입니다.

## 🛠️ 리뷰 요청 사항 (선택 사항)

-

## 📸 스크린샷 (선택 사항)

- 결과 화면입니다.
<img width="2842" height="1150" alt="image" src="https://github.com/user-attachments/assets/9ff466ca-67dd-4b86-9863-f66ca74c2d8d" />

