### PR TITLE
refactor: 페이지네이션 현재 페이지 사용자 입력 방어 로직 추가

### DIFF
--- a/src/components/common/Pagination/index.jsx
+++ b/src/components/common/Pagination/index.jsx
@@ -6,9 +6,11 @@ import { ArrowLeftIcon, ArrowRightIcon } from "@/assets/icons/Icons";
 
 export default function Pagination({ totalPage = 1 }) {
   const [searchParams] = useSearchParams();
-  const currentPage = Number(searchParams.get("page")) || 1;
 
+  const rawCurrentPage = Number(searchParams.get("page")) || 1;
   const safeTotalPage = Math.max(1, totalPage);
+  const currentPage =
+    rawCurrentPage > safeTotalPage ? safeTotalPage : rawCurrentPage;
 
   const pages = generatePage(currentPage, safeTotalPage);
   const prevPage = Math.max(1, currentPage - 1);


### PR DESCRIPTION
## 💡 작업 내용

- 사용자가 page=99999 같은 값을 입력했을 때 페이지네이션을 2페이지에 위치시키는 리팩토링입니다.
- 사용자가 음수값을 입력하는 경우도 고려해봤으나 그정도면 그냥 악의적은 사용자라 신경 안 썼습니다. (코드가 지저분해짐)

## 🛠️ 리뷰 요청 사항 (선택 사항)

- 이 코드는 페이지네이션 UI만 해당하는 코드입니다. 실제 데이터 렌더링은 해당 페이지에서 방어해야 할듯 합니다.
- 사실 생각해보니 페이지에서 방어를 하고 url이 바뀌면 페이지네이션 UI도 저절로 바뀌어서 방어 코드가 필요 없지 않나? 싶은 생각이 드네요?