### PR TITLE
refactor: FeedHeader에서 사용하는 옵저버 위치 변경

### DIFF
--- a/src/components/containers/Question/FeedHeader/FeedHeader.jsx
+++ b/src/components/containers/Question/FeedHeader/FeedHeader.jsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 import LogoImg from "@/assets/img/LogoImg";
@@ -10,11 +10,26 @@ import ScrollShareButtons from "@/components/containers/Question/FeedHeader/Scro
 
 import * as S from "@/components/containers/Question/FeedHeader/FeedHeader.style";
 
-const FeedHeader = forwardRef(({ subjectData, $isScroll }, ref) => {
+const FeedHeader = ({ subjectData }) => {
+  const [isHeaderVisible, setIsHeaderVisible] = useState(false);
+  const headerRef = useRef(null);
+
+  /* header scroll observer */
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsHeaderVisible(!entry.isIntersecting);
+      },
+      { threshold: 0 },
+    );
+    if (headerRef.current) observer.observe(headerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <>
       {/* 스크롤 안했을 때 헤더  */}
-      <S.MainHeader $hidden={$isScroll} ref={ref}>
+      <S.MainHeader $hidden={isHeaderVisible} ref={headerRef}>
         <S.ProfileContainer>
           <LogoImg width={170} as={Link} to="/" />
           <FeedProfile subjectData={subjectData} />
@@ -23,17 +38,17 @@ const FeedHeader = forwardRef(({ subjectData, $isScroll }, ref) => {
       </S.MainHeader>
 
       {/* 스크롤 헤더  */}
-      <S.ScrollContainer $visible={$isScroll}>
+      <S.ScrollContainer $visible={isHeaderVisible}>
         <S.PrevButton as={Link} to="/list">
           <ArrowLeftIcon size={44} />
         </S.PrevButton>
         <S.ScrollFeedProfile>
-          <FeedProfile subjectData={subjectData} $isScroll={$isScroll} />
+          <FeedProfile subjectData={subjectData} $isScroll={isHeaderVisible} />
         </S.ScrollFeedProfile>
-        <ScrollShareButtons $isScroll={$isScroll} />
+        <ScrollShareButtons $isScroll={isHeaderVisible} />
       </S.ScrollContainer>
     </>
   );
-});
+};
 
 export default FeedHeader;

--- a/src/pages/FeedPage.jsx
+++ b/src/pages/FeedPage.jsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 
 import { subjectApi } from "@/apis/subject";
 import FeedHeader from "@/components/containers/Question/FeedHeader/FeedHeader";
@@ -9,9 +9,6 @@ import * as S from "@/components/containers/Question/QuestionList.style";
 
 export default function FeedPage() {
   const [subjectData, setSubjectData] = useState(null);
-  const [isHeaderVisible, setIsHeaderVisible] = useState(false);
-
-  const headerRef = useRef(null);
 
   const navigate = useNavigate();
   const { subjectId, "*": subpath } = useParams();
@@ -38,25 +35,9 @@ export default function FeedPage() {
     fetchSubjectData();
   }, [subjectId]);
 
-  /* header scroll observer */
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsHeaderVisible(!entry.isIntersecting);
-      },
-      { threshold: 0 },
-    );
-    if (headerRef.current) observer.observe(headerRef.current);
-    return () => observer.disconnect();
-  }, []);
-
   return (
     <>
-      <FeedHeader
-        subjectData={subjectData}
-        $isScroll={isHeaderVisible}
-        ref={headerRef}
-      />
+      <FeedHeader subjectData={subjectData} />
       <S.Container>
         <QuestionList subjectId={subjectId} isAnswer={isAnswer} />
       </S.Container>


### PR DESCRIPTION
## 💡 작업 내용

- 기존에 FeedPage 에서 FeedHeader와 QuestionList를 렌더링을 하는 구조였는데요, FeedPage에서 헤더의 스크롤을 감지하는 useEffect가 실행될 때 마다 자식들이 리렌더링 되어 QuestionList가 리렌더링 되는 현상을 useEffect를 FeedHeader로 옮겨서 해결했습니다.

## 🛠️ 리뷰 요청 사항 (선택 사항)

- Page에 옵저버가 꼭 있어야 하는 명확한 이유를 찾지 못해서 일단 이렇게 작업을 해봤습니다.